### PR TITLE
claws-mail: update to 3.15.1

### DIFF
--- a/srcpkgs/claws-mail/template
+++ b/srcpkgs/claws-mail/template
@@ -1,28 +1,25 @@
 # Template file for 'claws-mail'
+
 pkgname=claws-mail
-version=3.15.0
+version=3.15.1
 revision=1
 build_style=gnu-configure
+short_desc="The user-friendly, lightweight, and fast email client"
 configure_args="--disable-static --disable-python-plugin --disable-perl-plugin"
 hostmakedepends="pkg-config python-devel"
 makedepends="poppler-glib-devel libarchive-devel libSM-devel
- libnotify-devel libcanberra-devel gpgme-devel gnutls-devel
- enchant-devel dbus-devel libetpan-devel libldap-devel
- libsoup-gnome-devel startup-notification-devel"
-short_desc="An extensible and secure e-mail client / newsreader with classic GUI"
-maintainer="Jakub Skrzypnik <jot.skrzyp@gmail.com>"
-license="GPL-3"
-homepage="http://claws-mail.org"
-distfiles="http://www.claws-mail.org/download.php?file=releases/claws-mail-${version}.tar.gz"
-checksum=662b64356d78083ac69cd7fe83f0cda27d60509bd45696689fda5774bea70761
+			 libnotify-devel libcanberra-devel gpgme-devel gnutls-devel
+			 enchant-devel dbus-devel libetpan-devel libldap-devel
+			 libsoup-gnome-devel startup-notification-devel"
+distfiles="http://www.claws-mail.org/download.php?file=releases/claws-mail-${version}.tar.xz"
+checksum="8d093c2f32db863c1141d56e35424c04ee48fe5d6adf4c7f349f647fa3149542"
 nocross=yes
 
 # TODO(dominikh): claws-mail is a mess. If we don't have python
 # installed at all, the build process will fail, even if we don't want
 # the python plugin. If we do have python installed, cross-compilation
 # fails. It's probably possible to fix the configure script to
-# cross-compile properly, but it's not worth the trouble. To me,
-# anyway.
+# cross-compile properly, but it's not worth the trouble. To me, anyway.
 
 claws-mail-devel_package() {
 	depends="${makedepends}"


### PR DESCRIPTION
29th August 2017                                    Claws Mail 3.15.1

		    CLAWS MAIL  RELEASE NOTES
                    http://www.claws-mail.org

Claws Mail is a GTK+ based, user-friendly, lightweight, and fast 
email client.

This is a bug-fix release:
~~~~~~~~~~~~~~~~~~~~~~~~~~

* Bug fixes:
	o bug 3348, 'Contact pictures not deleted when contact is
		     deleted'
	o bug 3721, 'Fails to build in Debian kfreebsd-*'
	o bug 3744, 'Crash upon deleting tags.'
	o bug 3822, 'AttRemover deletes message and fails to create
		     new one when disk is full'
	o bug 3828, '"Re-edit" should not recycle the Message-ID
	  	     header'
	o bug 3835, 'autogen.sh fails with invalid test on line 33'
	o bug 3855, 'segfault at startup with old profile and IMAP
		     account'
	o bug 3866, 'slibtool causes compile failure'
	o fix crash in sieve manager window when no account has sieve
	  enabled.
	o fix incorrect labels in folder selection dialog.
	o fix RSSyl feeds getting renamed to "Untitled feed".
	o fix Resent-Date value.
	o Fix typo around libarchive in configure.ac.

For further details of the numbered bugs and RFEs listed above
see http://claws-mail.org/bug/[BUG NUMBER]

---------------------------------------------------------------------
See ChangeLog for full information regarding changes in this release.